### PR TITLE
Fix warranty years smartsheet type

### DIFF
--- a/modules/core/project_settlement_jobs.py
+++ b/modules/core/project_settlement_jobs.py
@@ -97,7 +97,7 @@ PROJECT_SETTLEMENT_SYNC_CONFIG = SmartsheetSyncConfig(
     log_label="项目结算",
     dry_run_env="PROJECT_SETTLEMENT_SMARTSHEET_DRY_RUN",
     dedupe_prefix="wedoc-project-settlement",
-    numeric_fields={"fMqDX0", "fStRfT"},
+    numeric_fields={"fMqDX0", "fStRfT", "fl2HuS"},
     multi_text_fields={"f8xImK", "fESKNz", "f28Fkl"},
     identity_keys=("f04Gwj", "ftQMc5", "ftk5Tx", "ffFwIh", "fn8TJd", "signedDate", "f8xImK"),
 )

--- a/tests/unit/test_project_settlement_smartsheet_job.py
+++ b/tests/unit/test_project_settlement_smartsheet_job.py
@@ -132,7 +132,7 @@ class ProjectSettlementSmartsheetJobTest(unittest.TestCase):
         self.assertEqual(values["fMqDX0"], 3)
         self.assertEqual(values["f8xImK"], [{"text": "刘振海"}])
         self.assertEqual(values["fESKNz"], [{"text": "已发起"}])
-        self.assertEqual(values["fl2HuS"], "5")
+        self.assertEqual(values["fl2HuS"], 5)
 
         with sqlite3.connect(self.db_path) as conn:
             outbox_rows = conn.execute(


### PR DESCRIPTION
## What changed

- Treat the project-settlement `fl2HuS` (`warrantyYears`) field as numeric when building WeCom Smartsheet payloads.
- Update the unit-test expectation from the string `"5"` to the number `5`.

## Why

Metabase card 2015 now provides `warrantyYears`, and the corresponding WeCom Smartsheet field is configured as `type: number`. The sync previously serialized the value as text, causing WeCom to reject affected records with business error `2022017` and move them to `dead_letter`.

## Impact

New project-settlement records now send warranty years using the target field's required numeric type. The five affected dead-letter records were separately replayed successfully after correcting their payloads.

## Validation

- `python -m unittest tests.unit.test_project_settlement_smartsheet_job -v`
- 16 tests passed.
- `git diff --check` passed.